### PR TITLE
Static lease with dynamic address

### DIFF
--- a/apis/ipam/v1alpha1/ipv4pool_types.go
+++ b/apis/ipam/v1alpha1/ipv4pool_types.go
@@ -26,8 +26,8 @@ type IPv4PoolSpec struct {
 	CIDR string `json:"cidr"`
 
 	// Lease duration for leased ips.
-	// IPLease must be renewed in time or
-	// it will be deleted and reclaimed into the pool.
+	// IPv4Leases of type "Dynamic" must be renewed in time or
+	// will be deleted and reclaimed into the pool.
 	LeaseDuration *metav1.Duration `json:"leaseDuration,omitempty"`
 }
 

--- a/apis/ipam/v1alpha1/ipv6pool_types.go
+++ b/apis/ipam/v1alpha1/ipv6pool_types.go
@@ -26,8 +26,8 @@ type IPv6PoolSpec struct {
 	CIDR string `json:"cidr"`
 
 	// Lease duration for leased ips.
-	// IPLease must be renewed in time or
-	// it will be deleted and reclaimed into the pool.
+	// IPv6Leases of type "Dynamic" must be renewed in time or
+	// will be deleted and reclaimed into the pool.
 	LeaseDuration *metav1.Duration `json:"leaseDuration,omitempty"`
 }
 

--- a/apis/ipam/v1alpha1/types.go
+++ b/apis/ipam/v1alpha1/types.go
@@ -30,10 +30,12 @@ type IPLeaseType string
 
 const (
 	// Static IP Address allocation.
-	// The Lease will only successfully bind if the requested IPs are not yet occupied.
+	// Allocates an IP Address without respecting the pools LeaseDuration.
+	// Will try to allocate the requested static address if supplied.
 	IPLeaseTypeStatic = "Static"
 	// Dynamic IP Address allocation.
-	// Acquire any free IP address from the selected pool.
+	// Acquire any free IP address from the selected pool and respect LeaseDuration.
+	// IP addresses will be returned to the Pool if not renewed in time.
 	IPLeaseTypeDynamic = "Dynamic"
 )
 

--- a/config/crd/bases/ipam.routerd.net_ipv4pools.yaml
+++ b/config/crd/bases/ipam.routerd.net_ipv4pools.yaml
@@ -53,8 +53,9 @@ spec:
                 description: Subnet CIDR that this Pool is managing.
                 type: string
               leaseDuration:
-                description: Lease duration for leased ips. IPLease must be renewed
-                  in time or it will be deleted and reclaimed into the pool.
+                description: Lease duration for leased ips. IPv4Leases of type "Dynamic"
+                  must be renewed in time or will be deleted and reclaimed into the
+                  pool.
                 type: string
             required:
             - cidr

--- a/config/crd/bases/ipam.routerd.net_ipv6pools.yaml
+++ b/config/crd/bases/ipam.routerd.net_ipv6pools.yaml
@@ -53,8 +53,9 @@ spec:
                 description: Subnet CIDR that this Pool is managing.
                 type: string
               leaseDuration:
-                description: Lease duration for leased ips. IPLease must be renewed
-                  in time or it will be deleted and reclaimed into the pool.
+                description: Lease duration for leased ips. IPv6Leases of type "Dynamic"
+                  must be renewed in time or will be deleted and reclaimed into the
+                  pool.
                 type: string
             required:
             - cidr

--- a/config/samples/ipam_v1alpha1_iplease.static-specific.yaml
+++ b/config/samples/ipam_v1alpha1_iplease.static-specific.yaml
@@ -2,17 +2,21 @@
 apiVersion: ipam.routerd.net/v1alpha1
 kind: IPv4Lease
 metadata:
-  name: sample-thing
+  name: sample-router
 spec:
   pool:
     name: sample
   type: Static
+  static:
+    address: 172.20.0.1
 ---
 apiVersion: ipam.routerd.net/v1alpha1
 kind: IPv6Lease
 metadata:
-  name: sample-thing
+  name: sample-router
 spec:
   pool:
     name: sample
   type: Static
+  static:
+    address: fd9c:fd74:6b8d:1020::1

--- a/internal/controllers/ipam/iplease_controller.go
+++ b/internal/controllers/ipam/iplease_controller.go
@@ -59,7 +59,7 @@ func (r *IPLeaseReconciler) Reconcile(
 		return res, client.IgnoreNotFound(err)
 	}
 	defer func() {
-		if !iplease.GetDeletionTimestamp.IsZero() {
+		if !iplease.GetDeletionTimestamp().IsZero() {
 			// don't requeue deleted IPleases.
 			return
 		}

--- a/internal/controllers/ipam/iplease_controller_test.go
+++ b/internal/controllers/ipam/iplease_controller_test.go
@@ -19,6 +19,7 @@ package ipam
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/metal-stack/go-ipam"
 	"github.com/stretchr/testify/assert"
@@ -35,8 +36,6 @@ import (
 )
 
 func TestIPLeaseReconciler(t *testing.T) {
-	c := testutil.NewClient()
-
 	ippool := adapter.AdaptIPPool(&ipamv1alpha1.IPv4Pool{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pool",
@@ -45,85 +44,257 @@ func TestIPLeaseReconciler(t *testing.T) {
 		},
 		Spec: ipamv1alpha1.IPv4PoolSpec{
 			CIDR: "192.0.2.0/24",
+			LeaseDuration: &metav1.Duration{
+				Duration: time.Hour,
+			},
 		},
 	})
 	ippoolNN := types.NamespacedName{
 		Name:      ippool.GetName(),
 		Namespace: ippool.GetNamespace(),
 	}
-	iplease := adapter.AdaptIPLease(&ipamv1alpha1.IPv4Lease{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "lease",
-			Namespace: "default",
-		},
-		Spec: ipamv1alpha1.IPv4LeaseSpec{
-			Pool: ipamv1alpha1.LocalObjectReference{
-				Name: ippool.GetName(),
-			},
-			Type: ipamv1alpha1.IPLeaseTypeStatic,
-			Static: &ipamv1alpha1.IPLeaseStatic{
-				Address: "192.0.2.23",
-			},
-		},
-	})
-	ipleaseNN := types.NamespacedName{
-		Name:      iplease.GetName(),
-		Namespace: iplease.GetNamespace(),
-	}
 
 	ipv4 := &ipam.IP{
 		IP: netaddr.MustParseIP("192.0.2.23"),
 	}
-	ipam := &ipamMock{}
-	ipamCache := &ipamCacheMock{}
-	ipam.
-		On("AcquireSpecificIP", ippool.GetCIDR(), iplease.GetSpecStaticAddress()).
-		Return(ipv4, nil)
 
-	ipamCache.
-		On("Get", ippool).
-		Return(ipam, true)
+	t.Run("static fixed ip", func(t *testing.T) {
+		iplease := adapter.AdaptIPLease(&ipamv1alpha1.IPv4Lease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "lease",
+				Namespace: "default",
+			},
+			Spec: ipamv1alpha1.IPv4LeaseSpec{
+				Pool: ipamv1alpha1.LocalObjectReference{
+					Name: ippool.GetName(),
+				},
+				Type: ipamv1alpha1.IPLeaseTypeStatic,
+				Static: &ipamv1alpha1.IPLeaseStatic{
+					Address: "192.0.2.23",
+				},
+			},
+		})
+		ipleaseNN := types.NamespacedName{
+			Name:      iplease.GetName(),
+			Namespace: iplease.GetNamespace(),
+		}
 
-	c.On("Get", mock.Anything, ipleaseNN, mock.AnythingOfType("*v1alpha1.IPv4Lease")).
-		Run(func(args mock.Arguments) {
-			ipv4lease := args.Get(2).(*ipamv1alpha1.IPv4Lease)
-			*ipv4lease = *(iplease.ClientObject().(*ipamv1alpha1.IPv4Lease))
-		}).
-		Return(nil)
-	c.On("Get", mock.Anything, ippoolNN, mock.AnythingOfType("*v1alpha1.IPv4Pool")).
-		Run(func(args mock.Arguments) {
-			ipv4pool := args.Get(2).(*ipamv1alpha1.IPv4Pool)
-			*ipv4pool = *(ippool.ClientObject().(*ipamv1alpha1.IPv4Pool))
-		}).
-		Return(nil)
-	c.On("Update",
-		mock.Anything, mock.AnythingOfType("*v1alpha1.IPv4Lease"), mock.Anything).
-		Return(nil)
-	var leaseStatusUpdate *ipamv1alpha1.IPv4Lease
-	c.StatusMock.
-		On("Update",
+		ipam := &ipamMock{}
+		ipamCache := &ipamCacheMock{}
+		ipam.
+			On("AcquireSpecificIP", ippool.GetCIDR(), iplease.GetSpecStaticAddress()).
+			Return(ipv4, nil)
+
+		ipamCache.
+			On("Get", ippool).
+			Return(ipam, true)
+
+		c := testutil.NewClient()
+		c.On("Get", mock.Anything, ipleaseNN, mock.AnythingOfType("*v1alpha1.IPv4Lease")).
+			Run(func(args mock.Arguments) {
+				ipv4lease := args.Get(2).(*ipamv1alpha1.IPv4Lease)
+				*ipv4lease = *(iplease.ClientObject().(*ipamv1alpha1.IPv4Lease))
+			}).
+			Return(nil)
+		c.On("Get", mock.Anything, ippoolNN, mock.AnythingOfType("*v1alpha1.IPv4Pool")).
+			Run(func(args mock.Arguments) {
+				ipv4pool := args.Get(2).(*ipamv1alpha1.IPv4Pool)
+				*ipv4pool = *(ippool.ClientObject().(*ipamv1alpha1.IPv4Pool))
+			}).
+			Return(nil)
+		c.On("Update",
 			mock.Anything, mock.AnythingOfType("*v1alpha1.IPv4Lease"), mock.Anything).
-		Run(func(args mock.Arguments) {
-			leaseStatusUpdate = args.Get(1).(*ipamv1alpha1.IPv4Lease)
-		}).
-		Return(nil)
+			Return(nil)
+		var leaseStatusUpdate *ipamv1alpha1.IPv4Lease
+		c.StatusMock.
+			On("Update",
+				mock.Anything, mock.AnythingOfType("*v1alpha1.IPv4Lease"), mock.Anything).
+			Run(func(args mock.Arguments) {
+				leaseStatusUpdate = args.Get(1).(*ipamv1alpha1.IPv4Lease)
+			}).
+			Return(nil)
 
-	r := &IPLeaseReconciler{
-		Client:      c,
-		Log:         testutil.NewLogger(t),
-		IPAMCache:   ipamCache,
-		IPPoolType:  adapter.AdaptIPPool(&ipamv1alpha1.IPv4Pool{}),
-		IPLeaseType: adapter.AdaptIPLease(&ipamv1alpha1.IPv4Lease{}),
-	}
+		r := &IPLeaseReconciler{
+			Client:      c,
+			Log:         testutil.NewLogger(t),
+			IPAMCache:   ipamCache,
+			IPPoolType:  adapter.AdaptIPPool(&ipamv1alpha1.IPv4Pool{}),
+			IPLeaseType: adapter.AdaptIPLease(&ipamv1alpha1.IPv4Lease{}),
+		}
 
-	ctx := context.Background()
-	res, err := r.Reconcile(ctx, ctrl.Request{
-		NamespacedName: ipleaseNN,
+		ctx := context.Background()
+		res, err := r.Reconcile(ctx, ctrl.Request{
+			NamespacedName: ipleaseNN,
+		})
+		require.NoError(t, err)
+		assert.False(t, res.Requeue)
+		assert.Empty(t, res.RequeueAfter)
+
+		assert.Equal(t,
+			ipv4.IP.String(), leaseStatusUpdate.Status.Address)
+		assert.Nil(t, leaseStatusUpdate.Status.LeaseDuration)
 	})
-	require.NoError(t, err)
-	assert.False(t, res.Requeue)
-	assert.Empty(t, res.RequeueAfter)
 
-	assert.Equal(t,
-		iplease.GetSpecStaticAddress(), leaseStatusUpdate.Status.Address)
+	t.Run("static dynamic ip", func(t *testing.T) {
+		iplease := adapter.AdaptIPLease(&ipamv1alpha1.IPv4Lease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "lease",
+				Namespace: "default",
+			},
+			Spec: ipamv1alpha1.IPv4LeaseSpec{
+				Pool: ipamv1alpha1.LocalObjectReference{
+					Name: ippool.GetName(),
+				},
+				Type: ipamv1alpha1.IPLeaseTypeStatic,
+			},
+		})
+		ipleaseNN := types.NamespacedName{
+			Name:      iplease.GetName(),
+			Namespace: iplease.GetNamespace(),
+		}
+
+		ipam := &ipamMock{}
+		ipamCache := &ipamCacheMock{}
+		ipam.
+			On("AcquireIP", ippool.GetCIDR()).
+			Return(ipv4, nil)
+
+		ipamCache.
+			On("Get", ippool).
+			Return(ipam, true)
+
+		ipamCache.
+			On("Get", ippool).
+			Return(ipam, true)
+
+		c := testutil.NewClient()
+		c.On("Get", mock.Anything, ipleaseNN, mock.AnythingOfType("*v1alpha1.IPv4Lease")).
+			Run(func(args mock.Arguments) {
+				ipv4lease := args.Get(2).(*ipamv1alpha1.IPv4Lease)
+				*ipv4lease = *(iplease.ClientObject().(*ipamv1alpha1.IPv4Lease))
+			}).
+			Return(nil)
+
+		c.On("Get", mock.Anything, ippoolNN, mock.AnythingOfType("*v1alpha1.IPv4Pool")).
+			Run(func(args mock.Arguments) {
+				ipv4pool := args.Get(2).(*ipamv1alpha1.IPv4Pool)
+				*ipv4pool = *(ippool.ClientObject().(*ipamv1alpha1.IPv4Pool))
+			}).
+			Return(nil)
+		c.On("Update",
+			mock.Anything, mock.AnythingOfType("*v1alpha1.IPv4Lease"), mock.Anything).
+			Return(nil)
+		var leaseStatusUpdate *ipamv1alpha1.IPv4Lease
+		c.StatusMock.
+			On("Update",
+				mock.Anything, mock.AnythingOfType("*v1alpha1.IPv4Lease"), mock.Anything).
+			Run(func(args mock.Arguments) {
+				leaseStatusUpdate = args.Get(1).(*ipamv1alpha1.IPv4Lease)
+			}).
+			Return(nil)
+
+		r := &IPLeaseReconciler{
+			Client:      c,
+			Log:         testutil.NewLogger(t),
+			IPAMCache:   ipamCache,
+			IPPoolType:  adapter.AdaptIPPool(&ipamv1alpha1.IPv4Pool{}),
+			IPLeaseType: adapter.AdaptIPLease(&ipamv1alpha1.IPv4Lease{}),
+		}
+
+		ctx := context.Background()
+		res, err := r.Reconcile(ctx, ctrl.Request{
+			NamespacedName: ipleaseNN,
+		})
+		require.NoError(t, err)
+		assert.False(t, res.Requeue)
+		assert.Empty(t, res.RequeueAfter)
+
+		assert.Equal(t,
+			ipv4.IP.String(), leaseStatusUpdate.Status.Address)
+		assert.Nil(t, leaseStatusUpdate.Status.LeaseDuration)
+	})
+
+	t.Run("dynamic", func(t *testing.T) {
+		iplease := adapter.AdaptIPLease(&ipamv1alpha1.IPv4Lease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "lease",
+				Namespace: "default",
+			},
+			Spec: ipamv1alpha1.IPv4LeaseSpec{
+				Pool: ipamv1alpha1.LocalObjectReference{
+					Name: ippool.GetName(),
+				},
+				Type: ipamv1alpha1.IPLeaseTypeDynamic,
+			},
+		})
+		ipleaseNN := types.NamespacedName{
+			Name:      iplease.GetName(),
+			Namespace: iplease.GetNamespace(),
+		}
+
+		ipam := &ipamMock{}
+		ipamCache := &ipamCacheMock{}
+		ipam.
+			On("AcquireIP", ippool.GetCIDR()).
+			Return(ipv4, nil)
+
+		ipamCache.
+			On("Get", ippool).
+			Return(ipam, true)
+
+		ipamCache.
+			On("Get", ippool).
+			Return(ipam, true)
+
+		c := testutil.NewClient()
+		c.On("Get", mock.Anything, ipleaseNN, mock.AnythingOfType("*v1alpha1.IPv4Lease")).
+			Run(func(args mock.Arguments) {
+				ipv4lease := args.Get(2).(*ipamv1alpha1.IPv4Lease)
+				*ipv4lease = *(iplease.ClientObject().(*ipamv1alpha1.IPv4Lease))
+			}).
+			Return(nil)
+
+		c.On("Get", mock.Anything, ippoolNN, mock.AnythingOfType("*v1alpha1.IPv4Pool")).
+			Run(func(args mock.Arguments) {
+				ipv4pool := args.Get(2).(*ipamv1alpha1.IPv4Pool)
+				*ipv4pool = *(ippool.ClientObject().(*ipamv1alpha1.IPv4Pool))
+			}).
+			Return(nil)
+		c.On("Update",
+			mock.Anything, mock.AnythingOfType("*v1alpha1.IPv4Lease"), mock.Anything).
+			Return(nil)
+		var leaseStatusUpdate *ipamv1alpha1.IPv4Lease
+		c.StatusMock.
+			On("Update",
+				mock.Anything, mock.AnythingOfType("*v1alpha1.IPv4Lease"), mock.Anything).
+			Run(func(args mock.Arguments) {
+				leaseStatusUpdate = args.Get(1).(*ipamv1alpha1.IPv4Lease)
+			}).
+			Return(nil)
+
+		r := &IPLeaseReconciler{
+			Client:      c,
+			Log:         testutil.NewLogger(t),
+			IPAMCache:   ipamCache,
+			IPPoolType:  adapter.AdaptIPPool(&ipamv1alpha1.IPv4Pool{}),
+			IPLeaseType: adapter.AdaptIPLease(&ipamv1alpha1.IPv4Lease{}),
+		}
+
+		ctx := context.Background()
+		res, err := r.Reconcile(ctx, ctrl.Request{
+			NamespacedName: ipleaseNN,
+		})
+		require.NoError(t, err)
+		assert.False(t, res.Requeue)
+		leaseDuration, _ := ippool.GetSpecLeaseDuration()
+		assert.Equal(t, leaseDuration, res.RequeueAfter)
+
+		assert.Equal(t,
+			ipv4.IP.String(), leaseStatusUpdate.Status.Address)
+		if assert.NotNil(t, leaseStatusUpdate.Status.LeaseDuration) {
+			assert.Equal(
+				t, leaseDuration,
+				leaseStatusUpdate.Status.LeaseDuration.Duration)
+		}
+	})
 }


### PR DESCRIPTION
creating an IPLease of type static without specifying an address will dynamically allocate one from the pool.